### PR TITLE
WIP: Make sets case insensitive

### DIFF
--- a/src/main/kotlin/io/sylvanlibrary/api/ApplicationModule.kt
+++ b/src/main/kotlin/io/sylvanlibrary/api/ApplicationModule.kt
@@ -15,6 +15,7 @@ class ApplicationModule : AbstractModule() {
     bind(SetRepository::class.java).to(SetRepositoryImpl::class.java)
     bind(SetService::class.java).to(SetServiceImpl::class.java)
     bind(StatusRepository::class.java).to(StatusRepositoryImpl::class.java)
+    bind(DbConnection::class.java)
   }
 
   @Provides
@@ -30,7 +31,7 @@ class ApplicationModule : AbstractModule() {
   }
 
   @Provides
-  fun provideDbConnection(hikariConfig: HikariConfig): DBI {
-    return DBI(HikariDataSource(hikariConfig))
+  fun provideHikariConnection(hikariConfig: HikariConfig): HikariDataSource {
+    return HikariDataSource(hikariConfig)
   }
 }

--- a/src/main/kotlin/io/sylvanlibrary/api/daos/Dao.kt
+++ b/src/main/kotlin/io/sylvanlibrary/api/daos/Dao.kt
@@ -1,0 +1,5 @@
+package io.sylvanlibrary.api.daos
+
+interface Dao {
+  fun close()
+}

--- a/src/main/kotlin/io/sylvanlibrary/api/daos/SetDao.kt
+++ b/src/main/kotlin/io/sylvanlibrary/api/daos/SetDao.kt
@@ -7,16 +7,14 @@ import org.skife.jdbi.v2.sqlobject.Bind
 import org.skife.jdbi.v2.sqlobject.customizers.RegisterMapper
 
 @RegisterMapper(SetResultSetMapper::class)
-interface SetDao {
+interface SetDao: Dao {
 
   @SqlQuery("select * from sets")
   fun all(): List<Set>
 
-  @SqlQuery("select * from sets where name like :name")
+  @SqlQuery("select * from sets where UPPER(name) like UPPER(:name)")
   fun byName(@Bind("name") name: String): List<Set>
 
-  @SqlQuery("select * from sets where abbr = :abbr")
+  @SqlQuery("select * from sets where UPPER(abbr) = UPPER(:abbr)")
   fun byAbbr(@Bind("abbr") abbr: String): Set
-
-  fun close()
 }

--- a/src/main/kotlin/io/sylvanlibrary/api/daos/StatusDao.kt
+++ b/src/main/kotlin/io/sylvanlibrary/api/daos/StatusDao.kt
@@ -2,9 +2,7 @@ package io.sylvanlibrary.api.daos
 
 import org.skife.jdbi.v2.sqlobject.SqlQuery
 
-interface StatusDao {
+interface StatusDao: Dao {
   @SqlQuery("select count(*) from schema_version")
   fun check(): Int
-
-  fun close()
 }

--- a/src/main/kotlin/io/sylvanlibrary/api/repositories/DbConnection.kt
+++ b/src/main/kotlin/io/sylvanlibrary/api/repositories/DbConnection.kt
@@ -1,0 +1,19 @@
+package io.sylvanlibrary.api.repositories
+
+import com.google.inject.Inject
+import com.zaxxer.hikari.HikariDataSource
+import io.sylvanlibrary.api.daos.Dao
+import org.skife.jdbi.v2.DBI
+
+class DbConnection @Inject constructor(val hikariConn: HikariDataSource) {
+  fun <T: Dao, R> open(daoClass: Class<T>, dbOperation: (dao: T) -> R): R {
+    val dao = DBI(hikariConn).open(daoClass)
+
+    val result = dbOperation(dao)
+
+    dao.close()
+    hikariConn.close()
+
+    return result
+  }
+}

--- a/src/main/kotlin/io/sylvanlibrary/api/repositories/SetRepositoryImpl.kt
+++ b/src/main/kotlin/io/sylvanlibrary/api/repositories/SetRepositoryImpl.kt
@@ -3,34 +3,24 @@ package io.sylvanlibrary.api.repositories
 import com.google.inject.Inject
 import io.sylvanlibrary.api.daos.SetDao
 import io.sylvanlibrary.api.models.Set
-import org.skife.jdbi.v2.DBI
 import java.util.*
 
-class SetRepositoryImpl @Inject constructor(val conn: DBI): SetRepository {
+class SetRepositoryImpl @Inject constructor(val conn: DbConnection): SetRepository {
   override fun all(): List<Set> {
-    val setDao = conn.open(SetDao::class.java)
-    val result = setDao.all()
-
-    setDao.close()
-
-    return result
+    return conn.open(SetDao::class.java) { setDao ->
+      setDao.all()
+    }
   }
 
   override fun byName(name: String): List<Set> {
-    val setDao = conn.open(SetDao::class.java)
-    val results = setDao.byName(name)
-
-    setDao.close()
-
-    return results
+    return conn.open(SetDao::class.java) { setDao ->
+      setDao.byName("%$name%")
+    }
   }
 
   override fun byAbbr(abbr: String): Optional<Set> {
-    val setDao = conn.open(SetDao::class.java)
-    val result = Optional.ofNullable(setDao.byAbbr(abbr))
-
-    setDao.close()
-
-    return result
+    return conn.open(SetDao::class.java) { setDao ->
+      Optional.ofNullable(setDao.byAbbr(abbr))
+    }
   }
 }

--- a/src/main/kotlin/io/sylvanlibrary/api/repositories/StatusRepositoryImpl.kt
+++ b/src/main/kotlin/io/sylvanlibrary/api/repositories/StatusRepositoryImpl.kt
@@ -2,14 +2,12 @@ package io.sylvanlibrary.api.repositories
 
 import com.google.inject.Inject
 import io.sylvanlibrary.api.daos.StatusDao
-import org.skife.jdbi.v2.DBI
 
-class StatusRepositoryImpl @Inject constructor(val conn: DBI): StatusRepository {
+class StatusRepositoryImpl @Inject constructor(val conn: DbConnection): StatusRepository {
   override fun check(): Boolean {
-    val statusDao = conn.open(StatusDao::class.java)
-    val result = statusDao.check()
-
-    statusDao.close()
+    val result: Int = conn.open(StatusDao::class.java) { statusDao ->
+      statusDao.check()
+    }
 
     return result > 0
   }

--- a/src/main/kotlin/io/sylvanlibrary/api/services/SetServiceImpl.kt
+++ b/src/main/kotlin/io/sylvanlibrary/api/services/SetServiceImpl.kt
@@ -10,7 +10,7 @@ class SetServiceImpl @Inject constructor(val repo: SetRepository): SetService {
     val name = Optional.ofNullable(queryParams["name"])
 
     return if (name.isPresent) {
-      repo.byName("%${name.get()}%")
+      repo.byName(name.get())
     } else {
       repo.all()
     }


### PR DESCRIPTION
This PR fixes a bug in the `Set` endpoints that made filtering and viewing case-sensitive. It also does a refactor on the DB layer to handle automatically properly closing DB connections.

Fixes #18 

### Test Plan

1. `git fetch upstream pull/#/head:make-sets-case-insensitive`
1. `./gradlew test`
1. `./gradlew run`
1. The bug described in #18 should not be repo-able.
